### PR TITLE
CodeQL fixup test

### DIFF
--- a/cachi2/core/package_managers/generic/models.py
+++ b/cachi2/core/package_managers/generic/models.py
@@ -7,8 +7,16 @@ from typing import Literal, Union
 from urllib.parse import urljoin, urlparse
 
 from packageurl import PackageURL
-from pydantic import AnyUrl, BaseModel, ConfigDict, field_validator, model_validator
+from pydantic import (
+    AnyUrl,
+    BaseModel,
+    ConfigDict,
+    PlainSerializer,
+    field_validator,
+    model_validator,
+)
 from pydantic_core.core_schema import ValidationInfo
+from typing_extensions import Annotated
 
 from cachi2.core.checksum import ChecksumInfo
 from cachi2.core.errors import PackageManagerError
@@ -88,7 +96,7 @@ class LockfileArtifactUrl(LockfileArtifactBase):
     :param download_url: The URL to download the artifact from.
     """
 
-    download_url: AnyUrl
+    download_url: Annotated[AnyUrl, PlainSerializer(lambda url: str(url), return_type=str)]
 
     def resolve_filename(self) -> str:
         """Resolve the filename of the artifact."""
@@ -120,7 +128,7 @@ class LockfileArtifactUrl(LockfileArtifactBase):
 class LockfileArtifactMavenAttributes(BaseModel):
     """Attributes for a Maven artifact in the lockfile."""
 
-    repository_url: AnyUrl
+    repository_url: Annotated[AnyUrl, PlainSerializer(lambda url: str(url), return_type=str)]
     group_id: str
     artifact_id: str
     version: str

--- a/cachi2/core/package_managers/generic/models.py
+++ b/cachi2/core/package_managers/generic/models.py
@@ -24,6 +24,7 @@ from cachi2.core.models.sbom import Component, ExternalReference
 from cachi2.core.rooted_path import RootedPath
 
 CHECKSUM_FORMAT = re.compile(r"^[a-zA-Z0-9]+:[a-zA-Z0-9]+$")
+SerializedUrl = Annotated[AnyUrl, PlainSerializer(lambda url: str(url), return_type=str)]
 
 
 class LockfileMetadata(BaseModel):
@@ -96,7 +97,7 @@ class LockfileArtifactUrl(LockfileArtifactBase):
     :param download_url: The URL to download the artifact from.
     """
 
-    download_url: Annotated[AnyUrl, PlainSerializer(lambda url: str(url), return_type=str)]
+    download_url: SerializedUrl
 
     def resolve_filename(self) -> str:
         """Resolve the filename of the artifact."""
@@ -128,7 +129,7 @@ class LockfileArtifactUrl(LockfileArtifactBase):
 class LockfileArtifactMavenAttributes(BaseModel):
     """Attributes for a Maven artifact in the lockfile."""
 
-    repository_url: Annotated[AnyUrl, PlainSerializer(lambda url: str(url), return_type=str)]
+    repository_url: SerializedUrl
     group_id: str
     artifact_id: str
     version: str

--- a/tests/unit/package_managers/test_generic.py
+++ b/tests/unit/package_managers/test_generic.py
@@ -3,7 +3,6 @@ from typing import Any, Type
 from unittest import mock
 
 import pytest
-from pydantic_core import Url
 
 from cachi2.core.errors import Cachi2Error, PackageRejected
 from cachi2.core.models.input import GenericPackageInput
@@ -335,15 +334,13 @@ def test_load_generic_lockfile_valid(rooted_tmp_path: RootedPath) -> None:
         "metadata": {"version": "1.0"},
         "artifacts": [
             {
-                "download_url": Url("https://example.com/artifact"),
+                "download_url": "https://example.com/artifact",
                 "filename": str(rooted_tmp_path.join_within_root("archive.zip")),
                 "checksum": "md5:3a18656e1cea70504b905836dee14db0",
             },
             {
                 "checksum": "md5:32112bed1914cfe3799600f962750b1d",
-                "download_url": Url(
-                    "https://example.com/more/complex/path/file.tar.gz?foo=bar#fragment"
-                ),
+                "download_url": "https://example.com/more/complex/path/file.tar.gz?foo=bar#fragment",
                 "filename": str(rooted_tmp_path.join_within_root("file.tar.gz")),
             },
         ],


### PR DESCRIPTION
# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
